### PR TITLE
選択した都道府県の人口構成を取得する処理を追加

### DIFF
--- a/src/_api/resas.ts
+++ b/src/_api/resas.ts
@@ -2,6 +2,7 @@
 
 import { Prefecture } from '@/_types/prefecture'
 import { handleFailed, handleSuceed, path, headers } from './index'
+import { populationStruct } from '@/_types/populationStructs'
 
 export const getPrefectures = async (): Promise<Prefecture[]> => {
   try {
@@ -9,6 +10,24 @@ export const getPrefectures = async (): Promise<Prefecture[]> => {
       method: 'GET',
       headers: headers,
     })
+    return handleSuceed(response)
+  } catch (error) {
+    return handleFailed(error)
+  }
+}
+
+export const getPopulationStruct = async (
+  prefCode: number
+): Promise<populationStruct> => {
+  try {
+    const params = `?cityCode=-&prefCode=${prefCode}`
+    const response = await fetch(
+      path(`/api/v1/population/composition/perYear${params}`),
+      {
+        method: 'GET',
+        headers: headers,
+      }
+    )
     return handleSuceed(response)
   } catch (error) {
     return handleFailed(error)

--- a/src/_components/FetchPrefectures.tsx
+++ b/src/_components/FetchPrefectures.tsx
@@ -5,8 +5,21 @@ import PrefecturesCheckbox from '@/_components/PrefecturesCheckbox'
 import { Prefecture } from '@/_types/prefecture'
 import { useEffect, useState } from 'react'
 
-const FetchPrefectures = () => {
-  const [prefectures, setPrefectures] = useState<Prefecture[]>([])
+type FetchPrefecturesProps = {
+  prefectures: Prefecture[]
+  setPrefectures: (prefectures: Prefecture[]) => void
+  checkedPrefectures: number[]
+  setCheckedPrefectures: React.Dispatch<React.SetStateAction<number[]>>
+}
+
+const FetchPrefectures = (props: FetchPrefecturesProps) => {
+  const {
+    prefectures,
+    setPrefectures,
+    checkedPrefectures,
+    setCheckedPrefectures,
+  } = props
+
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -36,7 +49,13 @@ const FetchPrefectures = () => {
       </div>
     )
 
-  return <PrefecturesCheckbox prefectures={prefectures} />
+  return (
+    <PrefecturesCheckbox
+      prefectures={prefectures}
+      checkedPrefectures={checkedPrefectures}
+      setCheckedPrefectures={setCheckedPrefectures}
+    />
+  )
 }
 
 export default FetchPrefectures

--- a/src/_components/GetPopulationStruct.tsx
+++ b/src/_components/GetPopulationStruct.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { getPopulationStruct } from '@/_api/resas'
+import { populationStruct } from '@/_types/populationStructs'
+import React, { useEffect, useState } from 'react'
+
+type GetPopulationStructProps = {
+  checkedPrefectures: number[]
+  populationStructs: populationStruct[]
+  setPopulationStructs: (populationStructs: populationStruct[]) => void
+}
+
+const GetPopulationStruct = (props: GetPopulationStructProps) => {
+  const { checkedPrefectures, populationStructs, setPopulationStructs } = props
+
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (checkedPrefectures.length === 0) return
+    ;(async () => {
+      try {
+        const data = await Promise.all(
+          checkedPrefectures.map(async (prefCode) => {
+            const response = await getPopulationStruct(prefCode)
+            return response
+          })
+        )
+        setPopulationStructs(data)
+      } catch (error) {
+        setError('Failed to fetch data')
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [checkedPrefectures])
+  if (populationStructs.length === 0)
+    return (
+      <div className="h-[100px] flex justify-center items-center">
+        都道府県を追加してください
+      </div>
+    )
+  if (loading)
+    return (
+      <div className="h-[100px] flex justify-center items-center">
+        Loading...
+      </div>
+    )
+  if (error)
+    return (
+      <div className="h-[100px] flex justify-center items-center">
+        人口構成の取得に失敗しました
+      </div>
+    )
+  return <></>
+}
+
+export default GetPopulationStruct

--- a/src/_components/PrefecturesCheckbox.tsx
+++ b/src/_components/PrefecturesCheckbox.tsx
@@ -1,18 +1,18 @@
 'use client'
 
-import React, { ChangeEvent, useState } from 'react'
+import React, { ChangeEvent } from 'react'
 import { Prefecture } from '@/_types/prefecture'
 
 type PrefecturesCheckboxProps = {
   prefectures: Prefecture[]
+  checkedPrefectures: number[]
+  setCheckedPrefectures: React.Dispatch<React.SetStateAction<number[]>>
 }
 
 const PrefecturesCheckbox = (props: PrefecturesCheckboxProps) => {
-  const { prefectures } = props
+  const { prefectures, checkedPrefectures, setCheckedPrefectures } = props
 
-  const [checkedPrefectures, setCheckedPrefectures] = useState<number[]>([])
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChangeCheckbox = (e: ChangeEvent<HTMLInputElement>) => {
     const prefCode = parseInt(e.target.id)
     setCheckedPrefectures((prev) => {
       return e.target.checked
@@ -28,7 +28,7 @@ const PrefecturesCheckbox = (props: PrefecturesCheckboxProps) => {
             <input
               type="checkbox"
               id={`${prefecture.prefCode}`}
-              onChange={handleChange}
+              onChange={handleChangeCheckbox}
               checked={checkedPrefectures.includes(prefecture.prefCode)}
             />
             <label htmlFor={`${prefecture.prefCode}`}>

--- a/src/_components/SearchPopulationStruct.tsx
+++ b/src/_components/SearchPopulationStruct.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import FetchPrefectures from '@/_components/FetchPrefectures'
+import GetPopulationStruct from '@/_components/GetPopulationStruct'
+import { populationStruct } from '@/_types/populationStructs'
+import { Prefecture } from '@/_types/prefecture'
+import React, { useState } from 'react'
+
+const SearchPopulationStruct = () => {
+  const [prefectures, setPrefectures] = useState<Prefecture[]>([])
+  const [checkedPrefectures, setCheckedPrefectures] = useState<number[]>([])
+  const [populationStructs, setPopulationStructs] = useState<
+    populationStruct[]
+  >([])
+
+  return (
+    <>
+      <FetchPrefectures
+        prefectures={prefectures}
+        setPrefectures={setPrefectures}
+        checkedPrefectures={checkedPrefectures}
+        setCheckedPrefectures={setCheckedPrefectures}
+      />
+      <GetPopulationStruct
+        checkedPrefectures={checkedPrefectures}
+        populationStructs={populationStructs}
+        setPopulationStructs={setPopulationStructs}
+      />
+    </>
+  )
+}
+
+export default SearchPopulationStruct

--- a/src/_types/populationStructs.ts
+++ b/src/_types/populationStructs.ts
@@ -1,0 +1,14 @@
+type yearData = {
+  year: number
+  value: number
+}
+
+type yearDatas = {
+  label: string
+  data: yearData[]
+}
+
+export type populationStruct = {
+  boundaryYear: number
+  data: yearDatas
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
-import FetchPrefectures from '@/_components/FetchPrefectures'
+import SearchPopulationStruct from '@/_components/SearchPopulationStruct'
 
 export default function Home() {
   return (
     <main className="px-[4%]">
       <h2 className="text-xl font-bold">都道府県</h2>
-      <FetchPrefectures />
+      <SearchPopulationStruct />
     </main>
   )
 }


### PR DESCRIPTION
## 変更したこと

- チェックボックスで選択した都道府県の人口構成を取得する処理を追加した
- ほかのコンポーネントで状態管理していたものを一つのコンポーネントで管理してコンポーネントごとの責務を持たせるようにした

## その他

- この実装では人口構成をグラフで出力する処理は実装しない
